### PR TITLE
Add pyyaml to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ channels:
 dependencies:
     - python=3.6
     - astropy
+    - pyyaml
     - cython
     - h5py
     - ipython


### PR DESCRIPTION
This PR adds pyyaml to the environment.yml.
It's used in the Astropy tutorial example where we write an ECSV file, which has a YAML header.

cc @adonath 
